### PR TITLE
Fix error with path parameter regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import qs from 'qs'
 
 const TAG = '[vue-resource-mock]'
 const MATCH_OPTIONS = {
-  segmentValueCharset: 'a-zA-Z0-9.:-_%'
+  segmentValueCharset: 'a-zA-Z0-9-.:_%'
 }
 const mapRoutes = (map) => {
   return Object.keys(map)


### PR DESCRIPTION
I try to match against a UUID but it doesn't work as expected, because hyphens aren't properly escaped in the code.