### PR TITLE
Update index.js to allow Arrays in shorthand creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ const mapRoutes = (map) => {
               handler: handler
             })
             break
+          case 'Array':
           case 'Object':
             result.push({
               method: method,
@@ -56,7 +57,7 @@ const mapRoutes = (map) => {
             })
             break
           default:
-            throw new Error('Routes must be an Object or Function or number(status code)')
+            throw new Error('Routes must be an Object, Array, Function or Number(status code)')
         }
         return result
       }, [])


### PR DESCRIPTION
Allow arrays to be passed through as a shortcut to 200 responses, the same as an Object. Works with using the verbose function creation, but would like it to be allowed in the shorthand too!